### PR TITLE
Fixed DecoratorContinue never calling the CanRunDecoratorDelegate

### DIFF
--- a/TreeSharp/DecoratorContinue.cs
+++ b/TreeSharp/DecoratorContinue.cs
@@ -60,7 +60,15 @@ namespace TreeSharp
 
         public override IEnumerable<RunStatus> Execute(object context)
         {
-            if (!CanRun(context))
+			if (Runner != null)
+            {
+                if (!Runner(context))
+                {
+                    yield return RunStatus.Success;
+                    yield break;
+                }
+            }
+            else if (!CanRun(context))
             {
                 yield return RunStatus.Success;
                 yield break;


### PR DESCRIPTION
The CanRunDecoratorDelegate was never run for the DecoratorContinue component. I have added the necessary code to ensure it matches Decorator's execute method, but instead returnings Success.